### PR TITLE
fix ace jump for spacemacs buffer

### DIFF
--- a/spacemacs/packages.el
+++ b/spacemacs/packages.el
@@ -151,10 +151,14 @@
       (defun spacemacs/ace-buffer-links ()
         "Ace jump to links in `spacemacs' buffer."
         (interactive)
-        (ali-generic
-         (spacemacs//collect-spacemacs-buffer-links)
-         (forward-char 1)
-         (widget-button-press (point)))))))
+        (let ((res (avy--with-avy-keys spacemacs/ace-buffer-links
+                    (avy--process
+                        (spacemacs//collect-spacemacs-buffer-links)
+                        #'avy--overlay-pre))))
+            (when res
+            (goto-char (1+ res))
+            (widget-button-press (point))))))))
+
 
 (defun spacemacs/init-ace-window ()
   (use-package ace-window


### PR DESCRIPTION
ali-generic was removed from ace-link so this updates the code according to the new api.
It works but the overlay on paths have a one char offset because of the regex
I let it like that because I'm not sure if this was meant to capture other kinds of link.
